### PR TITLE
ci: create release branch after PR merge

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,69 @@
+name: Create release branch
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  create-release-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release branch at merge commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const sourceBranch = pullRequest.head.ref;
+            const separator = sourceBranch.indexOf("/");
+            const releaseName =
+              separator === -1
+                ? sourceBranch
+                : sourceBranch.slice(separator + 1);
+            const releaseBranch = `release/${releaseName}`;
+            const mergeCommit = pullRequest.merge_commit_sha;
+
+            core.info(
+              `Creating ${releaseBranch} at merge commit ${mergeCommit}`
+            );
+
+            try {
+              const existing = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${releaseBranch}`,
+              });
+
+              if (existing.data.object.sha === mergeCommit) {
+                core.notice(
+                  `${releaseBranch} already exists at ${mergeCommit}; no change needed.`
+                );
+                return;
+              }
+
+              core.setFailed(
+                `${releaseBranch} already exists at ${existing.data.object.sha}; refusing to move it to ${mergeCommit}.`
+              );
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/heads/${releaseBranch}`,
+              sha: mergeCommit,
+            });
+
+            core.notice(
+              `Created ${releaseBranch} at merge commit ${mergeCommit}.`
+            );


### PR DESCRIPTION
## Summary
- create a release branch automatically after a pull request is merged into `main`
- convert the source branch to the existing `release/<name>` convention
- create the release branch at the exact merge commit
- avoid moving an existing release branch; matching branches are treated as a safe no-op

## Validation
- workflow YAML parses successfully
- verified naming for prefixed and unprefixed source branches